### PR TITLE
Create standalone Emacs.app

### DIFF
--- a/README.org
+++ b/README.org
@@ -12,3 +12,7 @@ see https://qiita.com/takaxp/items/e07bb286d80fa9dd8e05
  - Emacs HEAD, 27.0.60 (emacs-27.1-inline.patch)
  - Emacs 26.3, 26.2, 26.1 (emacs-25.2-inline.patch)
  - Emacs 25.2, 25.3 (emacs-25.2-inline.patch)
+
+** My contribution
+ - Use extra libraries from https://github.com/paaguti/rudix
+ - Create a standalone distributable Emacs.app

--- a/README.org
+++ b/README.org
@@ -14,5 +14,5 @@ see https://qiita.com/takaxp/items/e07bb286d80fa9dd8e05
  - Emacs 25.2, 25.3 (emacs-25.2-inline.patch)
 
 ** My contribution
- - Use extra libraries from https://github.com/paaguti/rudix
- - Create a standalone distributable Emacs.app
+ - Create a standalone distributable Emacs.app local libraries from Rudix or brew
+ - Tested with libraries from my Rudix fork https://github.com/paaguti/rudix

--- a/README.org
+++ b/README.org
@@ -14,5 +14,5 @@ see https://qiita.com/takaxp/items/e07bb286d80fa9dd8e05
  - Emacs 25.2, 25.3 (emacs-25.2-inline.patch)
 
 ** My contribution
- - Create a standalone distributable Emacs.app local libraries from Rudix or brew
- - Tested with libraries from my Rudix fork https://github.com/paaguti/rudix
+ - Create a standalone distributable Emacs.app that uses local libraries from Rudix or brew
+ - Tested with libraries from my Rudix fork https://github.com/paaguti/rudix and OSX 10.13.6

--- a/build/emacs-27.1.sh
+++ b/build/emacs-27.1.sh
@@ -5,6 +5,11 @@ MACSDK=`xcrun --show-sdk-path`
 export LIBXML2_CFLAGS="-I${MACSDK}/usr/include/libxml2"
 export LIBXML2_LIBS="-lxml2"
 
+#
+# For BREW, change to
+# LOCAL_BASE=/opt/local
+LOCAL_BASE=/usr/local
+
 cd ~/Desktop
 git clone git://git.sv.gnu.org/emacs.git
 git clone --depth 1 https://github.com/takaxp/ns-inline-patch.git
@@ -15,10 +20,25 @@ patch -p1 < ../ns-inline-patch/emacs-27.1-inline.patch
 
 sleep 5
 ./autogen.sh
-./configure CC=clang --without-x --with-ns --with-modules
+#./configure CC=clang --without-x --with-ns --with-modules
+./configure --without-x --with-ns --with-modules --enable-silent-rules \
+			PKG_CONFIG_PATH=${LOCAL_BASE}/lib/pkgconfig \
+			LDFLAGS="-L${LOCAL_BASE}/lib" CPPFLAGS="-I${LOCAL_BASE}/include" \
+			CC=clang OBJC=clang CFLAGS="-g -O2"
+
 CORES=
 #CORES=4
 make bootstrap -j$CORES
 make install -j$CORES
+
+#
+# Inspired by
+# https://www.reddit.com/r/emacs/comments/bclyyc/building_emacs_from_source_on_macos/
+#
+mkdir nextstep/Emacs.app/Contents/Frameworks
+/usr/bin/python -m macholib standalone nextstep/Emacs.app
+#
+#
+#
 cd ./nextstep
 open .


### PR DESCRIPTION
Please consider my contribution that creates a standalone Emacs.app.

Background: I have ported a lot of GNU utilities to macOS for OSX 10.13 wuth a fork of Rudix
I'm currently running a full development environment on my Macbook Pro and a subset of these
on a smaller Macbook Air.
I wanted to make a self-contained Emacs.app for it.

Thank you very much for you build scripts